### PR TITLE
RFC 4649: Add Relay Agent Remote-ID Option.

### DIFF
--- a/const.go
+++ b/const.go
@@ -112,6 +112,9 @@ const (
 	OptionIAPD     OptionCode = 25
 	OptionIAPrefix OptionCode = 26
 
+	// RFC 4649
+	OptionRemoteIdentifier OptionCode = 37
+
 	// RFC 5970
 	OptionBootFileURL    OptionCode = 59
 	OptionBootFileParam  OptionCode = 60

--- a/options.go
+++ b/options.go
@@ -437,6 +437,26 @@ func (o Options) IAPrefix() ([]*IAPrefix, bool, error) {
 	return iaprefix, true, nil
 }
 
+// RemoteIdentifier returns the Remote Identifier, described in RFC 4649.
+//
+// This option may be added by DHCPv6 relay agents that terminate
+// switched or permanent circuits and have mechanisms to identify the
+// remote host end of the circuit.
+//
+// The boolean return value indicates if OptionRemoteIdentifier was present in the
+// Options map.  The error return value indicates if any errors were present
+// in the class data.
+func (o Options) RemoteIdentifier() (*RemoteIdentifier, bool, error) {
+	v, ok := o.Get(OptionRemoteIdentifier)
+	if !ok {
+		return nil, false, nil
+	}
+
+	r := new(RemoteIdentifier)
+	err := r.UnmarshalBinary(v)
+	return r, true, err
+}
+
 // BootFileURL returns the Boot File URL Option value, described in RFC 5970,
 // Section 3.1.
 //

--- a/remoteid.go
+++ b/remoteid.go
@@ -1,0 +1,57 @@
+package dhcp6
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// The definition of the remote-id carried in this option is vendor
+// specific.  The vendor is indicated in the enterprise-number field.
+// The remote-id field may be used to encode, for instance:
+// - a "caller ID" telephone number for dial-up connection
+// - a "user name" prompted for by a Remote Access Server
+// - a remote caller ATM address
+// - a "modem ID" of a cable data modem
+// - the remote IP address of a point-to-point link
+// - a remote X.25 address for X.25 connections
+// - an interface or port identifier
+type RemoteIdentifier struct {
+	// EnterpriseNumber specifies an IANA-assigned vendor Private Enterprise
+	// Number.
+	EnterpriseNumber uint32
+
+	// The opaque value for the remote-id.
+	RemoteId []byte
+}
+
+// MarshalBinary implements RemoteIdentifier, and allocates a byte slice containing the data
+// from a RemoteIdentifier.
+func (r *RemoteIdentifier) MarshalBinary() ([]byte, error) {
+	// 4 bytes: EnterpriseNumber
+	// N bytes: RemoteId
+	b := make([]byte, 4, 4+len(r.RemoteId))
+
+	binary.BigEndian.PutUint32(b, r.EnterpriseNumber)
+	b = append(b, r.RemoteId...)
+
+	return b, nil
+}
+
+// UnmarshalBinary implements RemoteIdentifier, and unmarshals a raw byte slice into a
+// RemoteIdentifier.  If the byte slice does not contain enough data to form a valid
+// RemoteIdentifier, io.ErrUnexpectedEOF is returned.
+func (r *RemoteIdentifier) UnmarshalBinary(b []byte) error {
+	// Too short to be valid RemoteIdentifier
+	if len(b) < 5 {
+		return io.ErrUnexpectedEOF
+	}
+
+	// Extract EnterpriseNumber
+	r.EnterpriseNumber = binary.BigEndian.Uint32(b[:4])
+
+	// Extract opaque value as remote-id
+	r.RemoteId = make([]byte, len(b[4:]))
+	copy(r.RemoteId, b[4:])
+
+	return nil
+}

--- a/remoteid_test.go
+++ b/remoteid_test.go
@@ -1,0 +1,77 @@
+package dhcp6
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestRemoteIdentifierMarshalBinary(t *testing.T) {
+	var tests = []struct {
+		desc             string
+		buf              []byte
+		remoteIdentifier *RemoteIdentifier
+	}{
+		{
+			desc: "all zero values",
+			buf:  bytes.Repeat([]byte{0}, 5),
+			remoteIdentifier: &RemoteIdentifier{
+				RemoteId: []byte{0},
+			},
+		},
+		{
+			desc: "[0, 0, 5, 0x58] EnterpriseNumber, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xe, 0xf] RemoteId",
+			buf:  []byte{0, 0, 5, 0x58, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xe, 0xf},
+			remoteIdentifier: &RemoteIdentifier{
+				EnterpriseNumber: 1368,
+				RemoteId:         []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xe, 0xf},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		want := tt.buf
+		got, err := tt.remoteIdentifier.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatalf("[%02d] test %q, unexpected RemoteIdentifier bytes for MarshalBinary(%v)\n- want: %v\n-  got: %v",
+				i, tt.desc, tt.buf, want, got)
+		}
+	}
+}
+
+func TestRemoteIdentifierUnmarshalBinary(t *testing.T) {
+	var tests = []struct {
+		buf              []byte
+		remoteIdentifier *RemoteIdentifier
+		err              error
+	}{
+		{
+			buf: []byte{0, 0, 5, 0x58, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xe, 0xf},
+			remoteIdentifier: &RemoteIdentifier{
+				EnterpriseNumber: 1368,
+				RemoteId:         []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xe, 0xf},
+			},
+		},
+		{
+			buf: bytes.Repeat([]byte{0}, 4),
+			err: io.ErrUnexpectedEOF,
+		},
+	}
+
+	for i, tt := range tests {
+		remoteIdentifier := new(RemoteIdentifier)
+		if want, got := tt.err, remoteIdentifier.UnmarshalBinary(tt.buf); want != got {
+			t.Fatalf("[%02d] unexpected error for parseRemoteIdentifier(%v):\n- want: %v\n-  got: %v", i, tt.buf, want, got)
+		}
+
+		if tt.err == nil {
+			if want, got := tt.remoteIdentifier, remoteIdentifier; !reflect.DeepEqual(want, got) {
+				t.Fatalf("[%02d] unexpected RemoteIdentifier for parseRemoteIdentifier(%v):\n- want: %v\n-  got: %v", i, tt.buf, want, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hello,
This PR is for RFC4649.
