### PR TITLE
dhcp6: do not skip options  with a lenght of 0

### DIFF
--- a/options.go
+++ b/options.go
@@ -110,9 +110,6 @@ func (o *Options) UnmarshalBinary(p []byte) error {
 		// n bytes: data
 		code := OptionCode(buf.Read16())
 		length := buf.Read16()
-		if length == 0 {
-			continue
-		}
 
 		// N bytes: option data
 		data := buf.Consume(int(length))

--- a/options_test.go
+++ b/options_test.go
@@ -178,9 +178,11 @@ func Test_parseOptions(t *testing.T) {
 			err:  ErrInvalidOptions,
 		},
 		{
-			desc:    "zero code, zero length option bytes",
-			buf:     []byte{0, 0, 0, 0},
-			options: Options{},
+			desc: "zero code, zero length option bytes",
+			buf:  []byte{0, 0, 0, 0},
+			options: Options{
+				0: [][]byte{{}},
+			},
 		},
 		{
 			desc: "zero code, zero length option bytes with trailing byte",
@@ -191,6 +193,13 @@ func Test_parseOptions(t *testing.T) {
 			desc: "zero code, length 3, incorrect length for data",
 			buf:  []byte{0, 0, 0, 3, 1, 2},
 			err:  ErrInvalidOptions,
+		},
+		{
+			desc: "Rapid Commit, length 0",
+			buf:  []byte{0, 14, 0, 0},
+			options: Options{
+				OptionRapidCommit: [][]byte{{}},
+			},
 		},
 		{
 			desc: "client ID, length 1, value [1]",


### PR DESCRIPTION
This make sure we can parse options with TLV value 0,
like RapidCommit.